### PR TITLE
Sprint_6

### DIFF
--- a/src/test/java/report_error.txt
+++ b/src/test/java/report_error.txt
@@ -62,5 +62,5 @@ Corrupted channel by directly writing to native stream in forked JVM 1. Stream '
 
 # Created at 2024-01-29T23:25:51.431
 Corrupted channel by directly writing to native stream in forked JVM 1. Stream '#'.
-
+.
 


### PR DESCRIPTION
Unable to create jacoco report file. Add report_error.txt (Corrupted channel by directly writing to native stream in forked JVM 1, FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed)